### PR TITLE
Add repository archived notice and workflow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Repository Archived
+Follow the new workflow at https://github.com/Consensys/linea-monorepo/blob/main/docs/linea-besu-package-releases.md
+
 # Linea Besu Upstream Distribution
 Github workflows to create and publish upstream Besu build for Linea.
 


### PR DESCRIPTION
Added an archived notice and new workflow link to README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds an archive notice and redirects readers to the new release workflow; no code or runtime behavior is affected.
> 
> **Overview**
> Marks the repository as **archived** in `README.md` and points users to the new release workflow documentation in `linea-monorepo`.
> 
> Also fixes a minor README formatting issue (duplicate/struck release link and missing newline at EOF).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf2ed5cdf74619f1b8de3d70a0ce77bd19531b55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->